### PR TITLE
Bug fix: npm WARN package.json No repository field verholpen

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/topicusonderwijs/embrah.git"
+  },
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
Fixes: npm WARN package.json ember-cli-embrah@0.0.4 No repository field
